### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/i18n-core/pom.xml
+++ b/i18n-core/pom.xml
@@ -27,7 +27,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>i18n-framework</artifactId>
     <version>1.4.3-SNAPSHOT</version>
   </parent>
@@ -47,7 +47,7 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <version>${project.version}</version>
         <executions>

--- a/i18n-core/pom.xml
+++ b/i18n-core/pom.xml
@@ -21,6 +21,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011 ForgeRock AS
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +29,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>i18n-framework</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-core</artifactId>
   <name>ForgeRock I18N Core</name>

--- a/i18n-jul/pom.xml
+++ b/i18n-jul/pom.xml
@@ -28,7 +28,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>i18n-framework</artifactId>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-jul</artifactId>
@@ -37,7 +37,7 @@
   <packaging>bundle</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-core</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
@@ -46,7 +46,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <version>${project.version}</version>
         <executions>

--- a/i18n-jul/pom.xml
+++ b/i18n-jul/pom.xml
@@ -21,6 +21,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011 ForgeRock AS
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +29,7 @@
   <parent>
     <artifactId>i18n-framework</artifactId>
     <groupId>org.forgerock.commons</groupId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-jul</artifactId>
   <name>ForgeRock I18N Java Logging Support</name>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>i18n-framework</artifactId>
     <version>1.4.3-SNAPSHOT</version>
   </parent>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -21,6 +21,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011 ForgeRock AS
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +29,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>i18n-framework</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -28,7 +28,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>i18n-framework</artifactId>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-slf4j</artifactId>
@@ -37,7 +37,7 @@
   <packaging>bundle</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.forgerock.commons</groupId>
+      <groupId>jp.openam.commons</groupId>
       <artifactId>i18n-core</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
@@ -53,7 +53,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>i18n-maven-plugin</artifactId>
         <version>${project.version}</version>
         <executions>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -21,6 +21,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011 ForgeRock AS
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +29,7 @@
   <parent>
     <artifactId>i18n-framework</artifactId>
     <groupId>org.forgerock.commons</groupId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-slf4j</artifactId>
   <name>ForgeRock I18N SLF4J Support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>1.2.1</version>
+    <version>2.0.7-SNAPSHOT</version>
   </parent>
   <groupId>jp.openam.commons</groupId>
   <artifactId>i18n-framework</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.forgerock</groupId>
+    <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
     <version>1.2.1</version>
   </parent>
-  <groupId>org.forgerock.commons</groupId>
+  <groupId>jp.openam.commons</groupId>
   <artifactId>i18n-framework</artifactId>
   <version>1.4.3-SNAPSHOT</version>
   <name>ForgeRock I18N Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,49 +38,17 @@
   <version>1.4.3-SNAPSHOT</version>
   <name>ForgeRock I18N Framework</name>
   <description>A common framework for embedding localizable messages in applications</description>
-  <url>http://commons.forgerock.org/i18n-framework</url>
+  <url>https://github.com/openam-jp/forgerock-i18n-framework</url>
   <packaging>pom</packaging>
   <issueManagement>
-    <system>Jira</system>
-    <url>https://bugster.forgerock.org/jira/browse/CINTFR</url>
+    <system>GitHub</system>
+    <url>https://github.com/openam-jp/forgerock-i18n-framework/issues</url>
   </issueManagement>
-  <mailingLists>
-    <mailingList>
-      <!-- TODO: need mailing list -->
-      <name>I18N Mailing List</name>
-      <archive>http://lists.forgerock.org/pipermail/opendj/</archive>
-      <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</subscribe>
-      <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</unsubscribe>
-      <post>opendj@forgerock.org</post>
-    </mailingList>
-  </mailingLists>
   <scm>
-    <url>https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</url>
-    <connection>scm:svn:https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</connection>
-    <developerConnection>scm:svn:https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</developerConnection>
+    <connection>scm:git:https://github.com/openam-jp/forgerock-i18n-framework.git</connection>
+    <developerConnection>scm:git:git@github.com:openam-jp/forgerock-i18n-framework.git</developerConnection>
+    <url>https://github.com/openam-jp/forgerock-i18n-framework</url>
   </scm>
-  <ciManagement>
-    <system>jenkins</system>
-    <url>http://builds.forgerock.org/job/Commons%20-%20I18N%20Framework/</url>
-    <notifiers>
-      <notifier>
-        <type>mail</type>
-        <sendOnError>true</sendOnError>
-        <sendOnFailure>true</sendOnFailure>
-        <sendOnSuccess>false</sendOnSuccess>
-        <sendOnWarning>false</sendOnWarning>
-        <!-- TODO: need mailing list -->
-        <address>opendj-dev@forgerock.org</address>
-      </notifier>
-    </notifiers>
-  </ciManagement>
-  <distributionManagement>
-    <site>
-      <id>forgerock.org</id>
-      <name>OpenDJ Community</name>
-      <url>scp://forgerock.org/var/www/vhosts/commons.forgerock.org/httpdocs/i18n-framework</url>
-    </site>
-  </distributionManagement>
   <modules>
     <module>i18n-maven-plugin</module>
     <module>i18n-core</module>
@@ -132,22 +100,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>http://maven.forgerock.org/repo/releases</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>forgerock-snapshots-repository</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>http://maven.forgerock.org/repo/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011 ForgeRock AS
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -34,7 +35,7 @@
   </parent>
   <groupId>org.forgerock.commons</groupId>
   <artifactId>i18n-framework</artifactId>
-  <version>1.4.2</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>ForgeRock I18N Framework</name>
   <description>A common framework for embedding localizable messages in applications</description>
   <url>http://commons.forgerock.org/i18n-framework</url>


### PR DESCRIPTION
## Analysis
This project is I18N Framework for ForgeRock projects.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-i18n-framework
```

## Regression testing
N/A