### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -36,17 +36,6 @@
   <packaging>maven-plugin</packaging>
   <name>ForgeRock I18N Maven Plugin</name>
   <description>A Maven plugin which generates I18N messages from property files</description>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>jp.openam.commons</groupId>
-        <artifactId>forgerock-bom</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
  !
  !      Copyright 2011 ForgeRock AS
  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+ !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,16 +36,25 @@
   <packaging>maven-plugin</packaging>
   <name>ForgeRock I18N Maven Plugin</name>
   <description>A Maven plugin which generates I18N messages from property files</description>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>jp.openam.commons</groupId>
+        <artifactId>forgerock-bom</artifactId>
+        <version>4.1.2-SNAPSHOT</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>2.0</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -36,17 +36,6 @@
   <name>ForgeRock I18N SLF4J Support</name>
   <description>This module provides an interface for efficiently writing localized messages out to a SLF4J Logger</description>
   <packaging>bundle</packaging>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>jp.openam.commons</groupId>
-        <artifactId>forgerock-bom</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>jp.openam.commons</groupId>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -22,6 +22,7 @@
  !
  !      Copyright 2011 ForgeRock AS
  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+ !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,6 +36,17 @@
   <name>ForgeRock I18N SLF4J Support</name>
   <description>This module provides an interface for efficiently writing localized messages out to a SLF4J Logger</description>
   <packaging>bundle</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>jp.openam.commons</groupId>
+        <artifactId>forgerock-bom</artifactId>
+        <version>4.1.2-SNAPSHOT</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>jp.openam.commons</groupId>
@@ -45,7 +57,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/i18n-slf4j/src/main/java/org/forgerock/i18n/slf4j/LocalizedMarker.java
+++ b/i18n-slf4j/src/main/java/org/forgerock/i18n/slf4j/LocalizedMarker.java
@@ -12,11 +12,14 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  *      Copyright 2014 ForgeRock AS
+ *      
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.i18n.slf4j;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Set;
 
 import org.forgerock.i18n.LocalizableMessage;
 import org.slf4j.Marker;
@@ -84,8 +87,9 @@ public class LocalizedMarker implements Marker {
 
     /** {@inheritDoc} */
     @Override
-    public Iterator<?> iterator() {
-        return Collections.emptySet().iterator();
+    public Iterator<Marker> iterator() {
+        Set<Marker> emptySet = Collections.emptySet();
+        return emptySet.iterator();
     }
 
     /** {@inheritDoc} */

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
   !
   !      Copyright 2011 ForgeRock AS
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -80,23 +81,31 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <maven.compiler.source>1.6</maven.compiler.source>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>jp.openam.commons</groupId>
+        <artifactId>forgerock-bom</artifactId>
+        <version>4.1.2-SNAPSHOT</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert</artifactId>
-      <version>1.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
